### PR TITLE
fix: pass prompt via stdin to prevent Windows hang and long prompt truncation

### DIFF
--- a/src/codex_as_mcp/server.py
+++ b/src/codex_as_mcp/server.py
@@ -99,9 +99,6 @@ async def spawn_agent(ctx: Context, prompt: str) -> str:
         output_path = Path(temp_dir) / "last_message.md"
         output_path.touch()
 
-        # Quote the prompt so Codex CLI receives it wrapped in "..."
-        quoted_prompt = '"' + prompt.replace('"', '\\"') + '"'
-
         cmd = [
             codex_exec,
             "e",
@@ -111,7 +108,7 @@ async def spawn_agent(ctx: Context, prompt: str) -> str:
             "--dangerously-bypass-approvals-and-sandbox",
             "--output-last-message",
             str(output_path),
-            quoted_prompt,
+            "-",  # read prompt from stdin
         ]
 
         # Initial progress ping
@@ -123,12 +120,26 @@ async def spawn_agent(ctx: Context, prompt: str) -> str:
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_build_child_env(),
             )
         except Exception as e:
             return f"Error: Failed to launch Codex agent: {e}"
+
+        # Send prompt via stdin, then close to signal EOF
+        try:
+            proc.stdin.write(prompt.encode("utf-8"))
+            await proc.stdin.drain()
+            proc.stdin.close()
+        except (BrokenPipeError, ConnectionResetError, OSError) as e:
+            # Child process exited before we finished writing
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            return f"Error: Failed to send prompt to Codex agent: {e}"
 
         stdout_task = asyncio.create_task(proc.stdout.read()) if proc.stdout else None
         stderr_task = asyncio.create_task(proc.stderr.read()) if proc.stderr else None


### PR DESCRIPTION
Closes kky42/codex-as-mcp#9.

### Background & Objective

On Windows, `spawn_agent` tool calls hang indefinitely. Additionally, long prompts (>500 characters with CJK/special characters) get silently truncated when passed as command-line arguments.

**Root causes:**
1. `create_subprocess_exec` doesn't set `stdin`, so the child inherits the MCP server's JSON-RPC stdin pipe. Codex CLI detects piped stdin and blocks on "Reading additional input from stdin..."
2. The manual quote escaping (`'"' + prompt.replace('"', '\\"') + '"'`) interacts poorly with `create_subprocess_exec`'s argv mode and Windows `.cmd` shims, causing long prompts to be corrupted or truncated

### Changes

| File | Change | +/- |
|------|--------|-----|
| `src/codex_as_mcp/server.py` | Pass prompt via `stdin=PIPE` instead of command-line arg; use Codex CLI's `-` flag; add `drain()` and error handling | +15 -4 |

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| `spawn_agent` on Windows | Hangs indefinitely | Returns normally (~10-15s) |
| Long prompt (500+ chars) | Silently truncated, agent receives incomplete instructions | Delivered intact via stdin, no length limit |
| Child process exits before prompt is fully written | Unhandled, potential zombie | `BrokenPipeError` caught, child killed, error returned |

### Why stdin PIPE

- Codex CLI natively supports `-` (read prompt from stdin) — this is an official interface
- `stdin=PIPE` prevents inheriting the MCP server's stdin (fixes the hang)
- stdin has no length limits (unlike command-line args)
- No shell escaping needed (avoids all quoting issues)

### Verification

- [x] Tested on Windows 11 with Codex CLI v0.128.0
- [x] Short prompt: returns in ~12s
- [x] Long prompt (~500 chars CJK + structured instructions): returns complete response in ~5min
- [ ] Verify on macOS/Linux (no behavioral change expected)
