### PR TITLE
fix: send Codex prompts via stdin and add cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build package
+        run: uv run python -m build

--- a/.github/workflows/live-codex.yml
+++ b/.github/workflows/live-codex.yml
@@ -21,7 +21,6 @@ jobs:
     name: Real provider smoke test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ secrets.CODEX_LIVE_API_KEY != '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/live-codex.yml
+++ b/.github/workflows/live-codex.yml
@@ -1,0 +1,56 @@
+name: Live Codex smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Codex model name to use for the live provider
+        required: true
+        default: gpt-5-mini
+      base_url:
+        description: Responses-compatible provider base URL. Direct chat-completions-only providers need a Responses-compatible proxy.
+        required: true
+        default: https://api.openai.com/v1
+      wire_api:
+        description: Codex wire_api for the provider. Current Codex requires responses.
+        required: true
+        default: responses
+
+jobs:
+  live-smoke:
+    name: Real provider smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ secrets.CODEX_LIVE_API_KEY != '' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex@latest
+
+      - name: Install Python dependencies
+        run: uv sync --group dev
+
+      - name: Run live Codex smoke test
+        env:
+          CODEX_LIVE_API_KEY: ${{ secrets.CODEX_LIVE_API_KEY }}
+          CODEX_LIVE_MODEL: ${{ inputs.model }}
+          CODEX_LIVE_BASE_URL: ${{ inputs.base_url }}
+          CODEX_LIVE_WIRE_API: ${{ inputs.wire_api }}
+        run: uv run python tests/live_codex_smoke.py

--- a/.github/workflows/live-codex.yml
+++ b/.github/workflows/live-codex.yml
@@ -6,11 +6,11 @@ on:
       model:
         description: Codex model name to use for the live provider
         required: true
-        default: gpt-5-mini
+        default: auto
       base_url:
         description: Responses-compatible provider base URL. Direct chat-completions-only providers need a Responses-compatible proxy.
         required: true
-        default: https://api.openai.com/v1
+        default: https://codex.ciii.club
       wire_api:
         description: Codex wire_api for the provider. Current Codex requires responses.
         required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ Inputs:
 - `prompt` (string): Everything the agent should know/do.
 
 Behavior:
-- Executes: `codex e --cd <server working directory> --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox "<prompt>"`
-- Wraps the prompt in quotes; escapes inner quotes.
+- Executes: `codex e --cd <server working directory> --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox -`
+- Sends the prompt through the child process stdin, then closes stdin.
 - Reads the Codex agent's last message from disk and returns it; heartbeats keep Inspector sessions alive.
 
 - **`spawn_agents_parallel`**: Run multiple Codex agents in parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Send Codex prompts through stdin using `codex e ... -` and close the pipe, preventing Windows MCP tool-call hangs caused by inherited JSON-RPC stdin and avoiding command-line prompt truncation/quoting issues.
+
+### Added
+- Add GitHub Actions CI across Linux, macOS, and Windows for Python 3.11 and 3.12.
+- Add regression tests for stdin prompt delivery and stdin write failure handling.
+
 ## [2026.2.2.1] - 2026-02-02
 
 ### 🛠️ Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2026.6.29.1] - 2026-06-29
 
 ### Fixed
 - Send Codex prompts through stdin using `codex e ... -` and close the pipe, preventing Windows MCP tool-call hangs caused by inherited JSON-RPC stdin and avoiding command-line prompt truncation/quoting issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add GitHub Actions CI across Linux, macOS, and Windows for Python 3.11 and 3.12.
 - Add regression tests for stdin prompt delivery and stdin write failure handling.
+- Add an optional manually triggered live Codex smoke workflow gated by `CODEX_LIVE_API_KEY` for maintainers with a Responses-compatible provider.
 
 ## [2026.2.2.1] - 2026-02-02
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ It exposes two tools that run Codex in the server's current working directory:
 - `spawn_agents_parallel(agents: list[dict])`
 
 Under the hood, each agent runs something like:
-`codex exec --cd <server cwd> --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox "<prompt>"`.
+`codex exec --cd <server cwd> --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox -`.
+
+The prompt is sent through stdin and then closed. This avoids command-line quoting/length issues and prevents Codex from accidentally reading from the MCP server's JSON-RPC stdin pipe.
 
 Note: `--dangerously-bypass-approvals-and-sandbox` disables sandboxing and confirmation prompts. Use this server only in repos you trust.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ args = ["codex-as-mcp@latest"]
 - `spawn_agent(prompt: str)` – Spawns an autonomous Codex subagent using the server's working directory and returns the agent's final message.
 - `spawn_agents_parallel(agents: list[dict])` – Spawns multiple Codex subagents in parallel; each item must include a `prompt` key and results include either an `output` or an `error` per agent.
 
+## Maintainer live smoke test
+
+The default CI uses unit tests and a fake subprocess path so it can run safely without credentials. Maintainers can additionally run the manually triggered **Live Codex smoke** GitHub Actions workflow with a real provider by setting repository secret `CODEX_LIVE_API_KEY` and providing a Responses-compatible `base_url`/`model` in the workflow inputs.
+
+Note: current Codex CLI rejects `wire_api = "chat"`; chat-completions-only providers such as direct DeepSeek API need either native Codex support for that wire API or a Responses-compatible proxy.
+
 ## Troubleshooting
 
 ### `spawn_agent` times out after ~60s

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 **通过 Codex-as-MCP 生成多个子代理**
 
-每个子代理都会在 MCP 服务器当前工作目录中以完全自主的方式运行 `codex e --dangerously-bypass-approvals-and-sandbox`。非常适合 Plus/Pro/Team 订阅用户使用 GPT-5 能力。
+每个子代理都会在 MCP 服务器当前工作目录中以完全自主的方式运行 `codex e --dangerously-bypass-approvals-and-sandbox -`，并通过 stdin 传入 prompt。非常适合 Plus/Pro/Team 订阅用户使用 GPT-5 能力。
 
 **在 Claude Code 中使用**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-as-mcp"
-version = "2026.2.2.1"
+version = "2026.6.29.1"
 description = "MCP server for delegating tasks to Codex CLI subagents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,7 @@ packages = ["src/codex_as_mcp"]
 
 [dependency-groups]
 dev = [
+    "build>=1.2.0",
+    "pytest>=8.0.0",
     "twine>=6.1.0",
 ]

--- a/src/codex_as_mcp/server.py
+++ b/src/codex_as_mcp/server.py
@@ -6,7 +6,9 @@ Tool: spawn_agent(prompt: str) -> str
 
 Command executed:
     codex e --cd {os.getcwd()} --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
-        --output-last-message {temp_output} "{prompt}"
+        --output-last-message {temp_output} -
+
+The prompt is written to the child process stdin and then stdin is closed.
 
 Notes:
 - No Authorization headers or extra auth flows are used.
@@ -99,9 +101,6 @@ async def spawn_agent(ctx: Context, prompt: str) -> str:
         output_path = Path(temp_dir) / "last_message.md"
         output_path.touch()
 
-        # Quote the prompt so Codex CLI receives it wrapped in "..."
-        quoted_prompt = '"' + prompt.replace('"', '\\"') + '"'
-
         cmd = [
             codex_exec,
             "e",
@@ -111,7 +110,7 @@ async def spawn_agent(ctx: Context, prompt: str) -> str:
             "--dangerously-bypass-approvals-and-sandbox",
             "--output-last-message",
             str(output_path),
-            quoted_prompt,
+            "-",  # read prompt from stdin
         ]
 
         # Initial progress ping
@@ -123,12 +122,29 @@ async def spawn_agent(ctx: Context, prompt: str) -> str:
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_build_child_env(),
             )
         except Exception as e:
             return f"Error: Failed to launch Codex agent: {e}"
+
+        # Send prompt via stdin and close it so Codex does not keep waiting for
+        # additional input from the inherited MCP JSON-RPC stdin pipe. This also
+        # avoids command-line length and quoting limits, especially on Windows.
+        try:
+            if proc.stdin is None:
+                return "Error: Failed to open stdin pipe for Codex agent."
+            proc.stdin.write(prompt.encode("utf-8"))
+            await proc.stdin.drain()
+            proc.stdin.close()
+        except (BrokenPipeError, ConnectionResetError, OSError) as e:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            return f"Error: Failed to send prompt to Codex agent: {e}"
 
         stdout_task = asyncio.create_task(proc.stdout.read()) if proc.stdout else None
         stderr_task = asyncio.create_task(proc.stderr.read()) if proc.stderr else None

--- a/tests/live_codex_smoke.py
+++ b/tests/live_codex_smoke.py
@@ -1,0 +1,85 @@
+"""Optional live Codex integration smoke test.
+
+This is intentionally not part of the default pytest suite. It requires a real
+Codex-compatible provider and API key, and is meant for a manually triggered
+GitHub Actions workflow or a maintainer machine.
+"""
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+
+from codex_as_mcp import server
+
+
+class DummyContext:
+    async def report_progress(self, *args, **kwargs):
+        return None
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+async def main() -> None:
+    api_key = require_env("CODEX_LIVE_API_KEY")
+    base_url = require_env("CODEX_LIVE_BASE_URL")
+    model = require_env("CODEX_LIVE_MODEL")
+    provider = os.environ.get("CODEX_LIVE_PROVIDER", "live_provider")
+    env_key = os.environ.get("CODEX_LIVE_ENV_KEY", "CODEX_LIVE_API_KEY")
+    wire_api = os.environ.get("CODEX_LIVE_WIRE_API", "responses")
+
+    with tempfile.TemporaryDirectory(prefix="codex-live-home-") as codex_home, tempfile.TemporaryDirectory(
+        prefix="codex-as-mcp-live-work-"
+    ) as workdir:
+        Path(codex_home, "config.toml").write_text(
+            f'''
+model = "{model}"
+model_provider = "{provider}"
+approval_policy = "never"
+sandbox_mode = "read-only"
+
+[model_providers.{provider}]
+name = "{provider}"
+base_url = "{base_url}"
+env_key = "{env_key}"
+wire_api = "{wire_api}"
+requires_openai_auth = false
+'''.lstrip(),
+            encoding="utf-8",
+        )
+
+        old_cwd = os.getcwd()
+        old_codex_home = os.environ.get("CODEX_HOME")
+        old_key = os.environ.get(env_key)
+        try:
+            os.environ["CODEX_HOME"] = codex_home
+            os.environ[env_key] = api_key
+            os.chdir(workdir)
+
+            prompt = (
+                "Reply with exactly this single token and nothing else: "
+                "CODEX_AS_MCP_LIVE_OK"
+            )
+            result = await asyncio.wait_for(server.spawn_agent(DummyContext(), prompt), timeout=180)
+            print(result)
+            if "CODEX_AS_MCP_LIVE_OK" not in result:
+                raise SystemExit("Live Codex smoke test did not return the expected token")
+        finally:
+            os.chdir(old_cwd)
+            if old_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = old_codex_home
+            if old_key is None:
+                os.environ.pop(env_key, None)
+            else:
+                os.environ[env_key] = old_key
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,104 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_as_mcp import server
+
+
+class DummyContext:
+    async def report_progress(self, *args, **kwargs):
+        return None
+
+
+class FakeStdin:
+    def __init__(self):
+        self.data = b""
+        self.closed = False
+
+    def write(self, data):
+        self.data += data
+
+    async def drain(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+class FakeStream:
+    def __init__(self, data=b""):
+        self.data = data
+
+    async def read(self):
+        return self.data
+
+
+def test_spawn_agent_sends_prompt_via_stdin_and_uses_dash(monkeypatch):
+    captured = {}
+    fake_stdin = FakeStdin()
+
+    class FakeProcess:
+        stdin = fake_stdin
+        stdout = FakeStream(b"codex stdout")
+        stderr = FakeStream(b"")
+
+        async def wait(self):
+            output_path = Path(captured["cmd"][captured["cmd"].index("--output-last-message") + 1])
+            output_path.write_text("final response", encoding="utf-8")
+            return 0
+
+        def kill(self):
+            captured["killed"] = True
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr(server, "_resolve_codex_executable", lambda: "codex")
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    prompt = 'hello "windows" 中文\n' * 100
+    result = asyncio.run(server.spawn_agent(DummyContext(), prompt))
+
+    assert result == "final response"
+    assert captured["cmd"][-1] == "-"
+    assert prompt not in captured["cmd"]
+    assert captured["kwargs"]["stdin"] == server.asyncio.subprocess.PIPE
+    assert fake_stdin.data == prompt.encode("utf-8")
+    assert fake_stdin.closed is True
+
+
+def test_spawn_agent_reports_stdin_write_failure(monkeypatch):
+    class BrokenStdin:
+        def write(self, data):
+            raise BrokenPipeError("closed")
+
+        async def drain(self):
+            return None
+
+        def close(self):
+            return None
+
+    proc = SimpleNamespace(
+        stdin=BrokenStdin(),
+        stdout=FakeStream(),
+        stderr=FakeStream(),
+        killed=False,
+    )
+
+    def kill():
+        proc.killed = True
+
+    proc.kill = kill
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        return proc
+
+    monkeypatch.setattr(server, "_resolve_codex_executable", lambda: "codex")
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    result = asyncio.run(server.spawn_agent(DummyContext(), "hello"))
+
+    assert result.startswith("Error: Failed to send prompt to Codex agent:")
+    assert proc.killed is True

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "codex-as-mcp"
-version = "2026.2.2.1"
+version = "2026.6.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -41,6 +41,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -147,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "codex-as-mcp"
-version = "2026.1.14.5"
+version = "2026.2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -155,6 +169,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "build" },
+    { name = "pytest" },
     { name = "twine" },
 ]
 
@@ -162,7 +178,11 @@ dev = [
 requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=1.12.4" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "twine", specifier = ">=6.1.0" }]
+dev = [
+    { name = "build", specifier = ">=1.2.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "twine", specifier = ">=6.1.0" },
+]
 
 [[package]]
 name = "colorama"
@@ -292,6 +312,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -485,6 +514,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -594,6 +632,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- fixes the Windows MCP tool-call hang by running `codex e ... -` and writing the prompt through the child process stdin
- closes stdin after writing so Codex cannot keep reading from the MCP JSON-RPC stdin pipe
- avoids command-line prompt quoting/truncation issues for long/CJK prompts
- adds regression tests for stdin delivery and stdin write failure handling
- adds GitHub Actions CI on Ubuntu, macOS, and Windows for Python 3.11/3.12
- adds an optional manually triggered live Codex smoke workflow gated by `CODEX_LIVE_API_KEY`
- defaults the live smoke workflow to the `codex-ciii-responses` Responses-compatible provider
- updates README/AGENTS/CHANGELOG docs

This incorporates the core fix proposed in #10 with additional tests and CI coverage.

Fixes #9.
Supersedes #10.

## Verification

- `uv run pytest -q` → 2 passed
- `uv run python -m build` → sdist and wheel built successfully
- GitHub CI passed on Ubuntu/macOS/Windows for Python 3.11/3.12
- Manual `Live Codex smoke` workflow passed against the configured Responses-compatible provider: https://github.com/kky42/codex-as-mcp/actions/runs/28367991997
